### PR TITLE
fix improperly formatted URL

### DIFF
--- a/src/com/webhoseio/sdk/WebhoseIOClient.java
+++ b/src/com/webhoseio/sdk/WebhoseIOClient.java
@@ -69,7 +69,7 @@ public class WebhoseIOClient {
         JsonElement o = parser.parse(response.toString());
 		
 		// Set next query URL
-		mNext = WEBHOSE_BASE_URL + o.getAsJsonObject().get("next");
+        	mNext = String.format("%s%s", WEBHOSE_BASE_URL, o.getAsJsonObject().get("next").getAsString());
 
 		return o;
 	}


### PR DESCRIPTION
Updated next URL string.

Old code would add in extra quotes to make the string invalid `http://webhose.io"/...<next url.../"`

New code fixes the issue.